### PR TITLE
Fix ignoring each table byte offset

### DIFF
--- a/Data/Gettext/GmoFile.hs
+++ b/Data/Gettext/GmoFile.hs
@@ -52,8 +52,13 @@ parseGmo = do
   transOffs <- getWord32
   hashSz <- getWord32
   hashOffs <- getWord32
+
+  skip $ max 0 (fromIntegral origOffs - 28)
   origs <- replicateM (fromIntegral size) getPair
+
+  skip $ max 0 (fromIntegral transOffs - fromIntegral origOffs - fromIntegral size * 8)
   trans <- replicateM (fromIntegral size) getPair
+
   return $ GmoFile {
               fMagic = magic,
               fRevision = revision,


### PR DESCRIPTION
Thank you for this useful library!

I found a problem about the GMO parser, and this patch fixes it.

Previously, the GMO parser doesn't consider byte offsets of original and translation tables. So the parsing result is broken. To fix this problem, read these tables at the specified byte offset of the start of the (G)MO file.