### PR TITLE
Various improvements to `hgettext`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,4 @@
+Next
+----
+
+- hgettext: added support for Unicode characters.

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -23,9 +23,6 @@ import Data.Version (showVersion)
 version = undefined
 -- import Paths_haskell_gettext (version)
 
--- xxx add default options
--- defaultOptions = Options "messages.po" ["__", "lprintf"] False
-
 toTranslate :: [String] -> H.ParseResult (H.Module H.SrcSpanInfo) -> [(H.SrcSpanInfo, String)]
 toTranslate f (H.ParseOk z) = nub [ (loc, s) | H.App _ (H.Var _ (H.UnQual _ (H.Ident _ x))) (H.Lit _ (H.String loc s _)) <- universeBi z, x `elem` f]
 toTranslate _ _ = []

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -1,56 +1,54 @@
--- (C)  vasylp https://github.com/vasylp/hgettext/blob/master/src/hgettext.hs
-
-import qualified Data.Text as T
-import qualified Data.Text.IO.Utf8 as Utf8
-import qualified Language.Haskell.Exts as H
+-- Originally copied from https://github.com/vasylp/hgettext/
+-- © 2009 Vasyl Pasternak, BSD-3-Clause.
 
 import Options
-
-import Data.Time
-
-import Data.Generics.Uniplate.Data
-
--- import Distribution.Simple.PreProcess.Unlit
-
-import Data.List
-import Data.Ord
-import Data.Function (on)
-
-import Data.Version (showVersion)
 import Paths_haskell_gettext (version)
 
-toTranslate :: [String] -> H.ParseResult (H.Module H.SrcSpanInfo) -> [(H.SrcSpanInfo, String)]
-toTranslate f (H.ParseOk z) = nub [ (loc, s) | H.App _ (H.Var _ (H.UnQual _ (H.Ident _ x))) (H.Lit _ (H.String loc s _)) <- universeBi z, x `elem` f]
-toTranslate _ _ = []
+import qualified Data.Generics.Uniplate.Data as G
+import qualified Data.Function as F
+import qualified Data.List as L
+import qualified Data.Ord as O
+import qualified Data.Text as T
+import qualified Data.Time as TM
+import qualified Data.Text.IO.Utf8 as Utf8
+import qualified Data.Version as V
+import qualified Language.Haskell.Exts as H
 
--- Create list of messages from a single file
-formatMessages :: String -> [(H.SrcSpanInfo, String)] -> String
-formatMessages path l = concat $ map potEntry $ nubBy ((==) `on` snd) $ sortBy (comparing snd) l
-    where potEntry (wl, s) = unlines [
-                             "#: " ++ showSrc wl,
-                             "msgid " ++ (showStringC s),
-                             "msgstr \"\"",
-                             ""
-                            ]
-          showSrc wl = path ++ ":" ++ show (H.srcSpanStartLine (H.srcInfoSpan wl)) ++ ":" ++ show (H.srcSpanStartColumn (H.srcInfoSpan wl))
 
--- Escape a string in a C-like fashion,
--- see https://www.ibm.com/docs/en/i/7.4?topic=literals-string
-showStringC :: String -> String
-showStringC s0 = '"' : concatMap showCharC s0 ++ "\""
+main :: IO ()
+main = do
+    opts <- parseOptions
+    process opts
+
+process :: Options -> IO ()
+process Options{printVersion = True} =
+        putStrLn $ "hgettext (from haskell-gettext), version " ++
+                     (V.showVersion version)
+process opts
+    | null (inputFiles opts) = do
+        putStrLn "hgettext: missing arguments"
+    | otherwise = do
+        t <- mapM read' (inputFiles opts)
+        pot <- formatPotFile $
+                 map (\(n,c) -> formatMessages n $
+                                  toTranslate (keywords opts) c) t
+        Utf8.writeFile (outputFile opts) (T.pack pot)
     where
-      showCharC '"' = "\\\""
-      showCharC '\\' = "\\\\"
-      showCharC '\n' = "\\n"
-      showCharC c = return c
+        read' :: FilePath ->
+                 IO (String, H.ParseResult (H.Module H.SrcSpanInfo))
+        read' "-" = getContents >>= \c -> return ("-", H.parseFileContents c)
+        read' f = H.parseFile f >>= \m -> return (f, m)
+
+-------------------------------------------------------------------------------
+-- Write
 
 
 formatPotFile :: [String] -> IO String
 formatPotFile ls = do
-    time <- getZonedTime
-    let timeStr = formatTime defaultTimeLocale "%F %R%z" time
+    time <- TM.getZonedTime
+    let timeStr = TM.formatTime TM.defaultTimeLocale "%F %R%z" time
     let header = formatPotHeader timeStr
-    return $ concat $ header: ls
+    return $ concat (header:ls)
   where
     formatPotHeader :: String -> String
     formatPotHeader timeStr =
@@ -70,26 +68,40 @@ formatPotFile ls = do
                 "\"Content-Transfer-Encoding: 8bit\\n\"",
                 ""]
 
-process :: Options -> IO ()
-process Options{printVersion = True} =
-        putStrLn $ "hgettext (from haskell-gettext), version " ++
-                     (showVersion version)
-process opts
-    | null (inputFiles opts) = do
-        putStrLn "hgettext: missing arguments"
-    | otherwise = do
-        t <- mapM read' (inputFiles opts)
-        pot <- formatPotFile $
-                 map (\(n,c) -> formatMessages n $
-                                  toTranslate (keywords opts) c) t
-        Utf8.writeFile (outputFile opts) (T.pack pot)
+-- Create list of messages from a single file.
+formatMessages :: String -> [(H.SrcSpanInfo, String)] -> String
+formatMessages path l =
+        let sorted = L.sortBy (O.comparing snd) l
+            nubbed = L.nubBy ((==) `F.on` snd) sorted
+        in concatMap potEntry nubbed
     where
-        read' :: FilePath ->
-                 IO (String, H.ParseResult (H.Module H.SrcSpanInfo))
-        read' "-" = getContents >>= \c -> return ("-", H.parseFileContents c)
-        read' f = H.parseFile f >>= \m -> return (f, m)
+        potEntry :: (H.SrcSpanInfo, String) -> String
+        potEntry (wl, s) = unlines
+                             ["#: " ++ showSrc wl,
+                              "msgid " ++ (showStringC s),
+                              "msgstr \"\"",
+                              ""]
 
-main :: IO ()
-main = do
-    opts <- parseOptions
-    process opts
+        showSrc :: H.SrcSpanInfo -> String
+        showSrc wl = path ++ ":" ++
+                     show (H.srcSpanStartLine (H.srcInfoSpan wl)) ++ ":" ++
+                     show (H.srcSpanStartColumn (H.srcInfoSpan wl))
+
+toTranslate :: [String] -> H.ParseResult (H.Module H.SrcSpanInfo) ->
+               [(H.SrcSpanInfo, String)]
+toTranslate f (H.ParseOk z) =
+        L.nub [(loc, s) |
+                H.App _ (H.Var _ (H.UnQual _ (H.Ident _ x)))
+                        (H.Lit _ (H.String loc s _)) <- G.universeBi z,
+                x `elem` f]
+toTranslate _ _ = []
+
+-- Escape a string in a C-like fashion,
+-- see https://www.ibm.com/docs/en/i/7.4?topic=literals-string
+showStringC :: String -> String
+showStringC s0 = '"' : concatMap showCharC s0 ++ "\""
+    where
+      showCharC '"' = "\\\""
+      showCharC '\\' = "\\\\"
+      showCharC '\n' = "\\n"
+      showCharC c = return c

--- a/exe/Options.hs
+++ b/exe/Options.hs
@@ -28,7 +28,9 @@ infoOpts = info (options <**> helper)
   <> header "hello - a test for optparse-applicative" )
 
 options :: Parser Options
-options = Options <$> inputs <*> outfile <*> many keyword <*> version
+options = Options <$> inputs <*> outfile <*> kwsDef <*> version
+    where
+        kwsDef = ("__" :) <$> many keyword
 
 inputs :: Parser [FilePath]
 inputs = many (strArgument (metavar "PATH..."))

--- a/exe/Options.hs
+++ b/exe/Options.hs
@@ -25,7 +25,7 @@ infoOpts :: ParserInfo Options
 infoOpts = info (options <**> helper)
   ( fullDesc
   <> progDesc "Extract translatable strings from Haskell source files."
-  <> header "hello - a test for optparse-applicative" )
+  <> header "hgettext (from haskell-gettext)" )
 
 options :: Parser Options
 options = Options <$> inputs <*> outfile <*> kwsDef <*> version

--- a/exe/Options.hs
+++ b/exe/Options.hs
@@ -21,7 +21,6 @@ parseOptions = execParser infoOpts
 -------------------------------------------------------------------------------
 -- Parsers/properties
 
--- xxx test help
 infoOpts :: ParserInfo Options
 infoOpts = info (options <**> helper)
   ( fullDesc
@@ -42,14 +41,14 @@ outfile = output <|> ((FP.<.> "po") <$> defaultDomain) <|> pure "messages.po"
             ( long "output"
             <> short 'o'
             <> metavar "FILE"
-            <> help "Write output to specified file." )
+            <> help "write output to specified file" )
 
         defaultDomain :: Parser FilePath
         defaultDomain = strOption
             ( long "default-domain"
             <> short 'd'
             <> metavar "NAME"
-            <> help "Use NAME.po instead of messages.po." )
+            <> help "use NAME.po instead of messages.po" )
 
 keyword :: Parser String
 keyword = strOption
@@ -58,10 +57,10 @@ keyword = strOption
                 <> metavar "WORD"
                 <> help "function names, in which searched words are \
                         \wrapped. Can be used multiple times, for multiple \
-                        \funcitons." )
+                        \funcitons" )
 
 version :: Parser Bool
 version = switch
             ( long "version"
             <> short 'v'
-            <> help "Print version of hgettext" )
+            <> help "print version of hgettext" )

--- a/exe/Options.hs
+++ b/exe/Options.hs
@@ -1,0 +1,67 @@
+module Options (
+        Options(..),
+        parseOptions
+    )
+        where
+
+import Options.Applicative
+
+import qualified System.FilePath as FP
+
+data Options = Options {
+      inputFiles :: [FilePath],
+      outputFile :: FilePath,
+      keywords :: [String],
+      printVersion :: Bool
+    } deriving Show
+
+parseOptions :: IO Options
+parseOptions = execParser infoOpts
+
+-------------------------------------------------------------------------------
+-- Parsers/properties
+
+-- xxx test help
+infoOpts :: ParserInfo Options
+infoOpts = info (options <**> helper)
+  ( fullDesc
+  <> progDesc "Extract translatable strings from Haskell source files."
+  <> header "hello - a test for optparse-applicative" )
+
+options :: Parser Options
+options = Options <$> inputs <*> outfile <*> many keyword <*> version
+
+inputs :: Parser [FilePath]
+inputs = many (argument str (metavar "PATH..."))
+
+outfile :: Parser FilePath
+outfile = output <|> ((FP.<.> "po") <$> defaultDomain) <|> pure "messages.po"
+    where
+        output :: Parser FilePath
+        output = strOption
+            ( long "output"
+            <> short 'o'
+            <> metavar "FILE"
+            <> help "Write output to specified file." )
+
+        defaultDomain :: Parser FilePath
+        defaultDomain = strOption
+            ( long "default-domain"
+            <> short 'd'
+            <> metavar "NAME"
+            <> help "Use NAME.po instead of messages.po." )
+
+keyword :: Parser String
+keyword = strOption
+                ( long "keyword"
+                <> short 'k'
+                <> metavar "WORD"
+                <> help "function names, in which searched words are \
+                        \wrapped. Can be used multiple times, for multiple \
+                        \funcitons." )
+
+version :: Parser Bool
+version = switch
+            ( long "version"
+            <> short 'v'
+            <> help "Print version of hgettext" )

--- a/exe/Options.hs
+++ b/exe/Options.hs
@@ -32,7 +32,7 @@ options :: Parser Options
 options = Options <$> inputs <*> outfile <*> many keyword <*> version
 
 inputs :: Parser [FilePath]
-inputs = many (argument str (metavar "PATH..."))
+inputs = many (strArgument (metavar "PATH..."))
 
 outfile :: Parser FilePath
 outfile = output <|> ((FP.<.> "po") <$> defaultDomain) <|> pure "messages.po"

--- a/haskell-gettext.cabal
+++ b/haskell-gettext.cabal
@@ -62,7 +62,9 @@ library
 executable hgettext
   import:            shared
   main-is:           Main.hs
-  other-modules:     Options
+  autogen-modules:   Paths_haskell_gettext
+  other-modules:     Options,
+                     Paths_haskell_gettext
   build-depends:     filepath >= 1.4 && < 1.6,
                      haskell-src-exts >= 1.18 && < 1.24,
                      old-locale >= 1.0 && < 1.1,

--- a/haskell-gettext.cabal
+++ b/haskell-gettext.cabal
@@ -62,9 +62,11 @@ library
 executable hgettext
   import:            shared
   main-is:           Main.hs
+  other-modules:     Options
   build-depends:     filepath >= 1.4 && < 1.6,
                      haskell-src-exts >= 1.18 && < 1.24,
-                     old-locale >= 1.0 && < 1.1
+                     old-locale >= 1.0 && < 1.1,
+                     optparse-applicative >= 0.18.1 && < 0.19,
                      time >= 1.5.0 && < 1.13,
                      uniplate >= 1.6.12 && < 1.7,
   hs-source-dirs:    exe/

--- a/haskell-gettext.cabal
+++ b/haskell-gettext.cabal
@@ -34,12 +34,13 @@ maintainer:          portnov84@rambler.ru
 copyright:           © 2017–2019 Ilya Portnov
 category:            Text
 build-type:          Simple
-extra-doc-files:     README.md
+extra-doc-files:     README.md, NEWS
 extra-source-files:  examples/gmodump.hs
                      examples/gmotest.hs
 
 common shared
-  build-depends:    base == 4.*
+  build-depends:    base == 4.*,
+                    text >= 2.1.2 && < 2.2,
   ghc-options:      -Wall
   default-language: Haskell2010
 
@@ -54,7 +55,6 @@ library
                        containers >=0.5 && < 0.7,
                        mtl >= 2.2.1 && < 2.4,
                        parsec >= 3.1.11 && < 3.2,
-                       text >= 1.2 && < 2.2,
                        time >=1.4 && < 1.13,
                        transformers >=0.3 && < 0.7
   hs-source-dirs:      lib/

--- a/lib/Data/Gettext.hs
+++ b/lib/Data/Gettext.hs
@@ -119,7 +119,7 @@ cgettext :: Catalog
          -> B.ByteString -- ^ Message context (@msgctxt@ line in @po@ file)
          -> B.ByteString -- ^ Original string
          -> T.Text
-cgettext gmo context key = gettext gmo (context `B.append` "\4" `B.append` key)
+cgettext gmo ctx key = gettext gmo (ctx `B.append` "\4" `B.append` key)
 
 -- | Translate a string and select correct plural form.
 -- Original single form must be defined in @po@ file in @msgid@ line.
@@ -140,8 +140,8 @@ cngettext :: Catalog
          -> B.ByteString  -- ^ Plural form in original language
          -> Int           -- ^ Number
          -> T.Text
-cngettext gmo context single plural n =
-  ngettext' gmo (context `B.append` "\4" `B.append` single `B.append` "\0" `B.append` plural) n
+cngettext gmo ctx single plural n =
+  ngettext' gmo (ctx `B.append` "\4" `B.append` single `B.append` "\0" `B.append` plural) n
 
 -- | Variant of @ngettext@ for case when for some reason there is only
 -- @msgid@ defined in @po@ file, and no @msgid_plural@, but there are some @msgstr[n]@.

--- a/lib/Data/Gettext/GmoFile.hs
+++ b/lib/Data/Gettext/GmoFile.hs
@@ -69,11 +69,3 @@ parseGmo = do
               fOriginals = origs,
               fTranslations = trans,
               fData = undefined }
-
-withGmoFile :: FilePath -> (GmoFile -> IO a) -> IO a
-withGmoFile path go = do
-  content <- L.readFile path
-  let gmo = (runGet parseGmo content) {fData = content}
-  result <- go gmo
-  return result
-

--- a/lib/Data/Gettext/Parsers.hs
+++ b/lib/Data/Gettext/Parsers.hs
@@ -38,8 +38,8 @@ type Headers = [Header]
 pHeader :: Parser Header
 pHeader = do
   name <- (many1 $ alphaNum <|> char '-') <?> "Header name"
-  char ':'
-  many $ oneOf " \t"
+  _ <- char ':'
+  _ <- many $ oneOf " \t"
   value <- many $ noneOf "\r\n"
   return (T.pack name, T.pack value)
 
@@ -51,8 +51,8 @@ pHeaders = pHeader `sepEndBy` newline
 -- NB: for now this function does not use Parsec.
 parseHeaders :: T.Text -> Either String Headers
 parseHeaders t = do
-  let lines = filter (not . T.null) $ T.splitOn "\n" t
-  forM lines $ \line ->
+  let ls = filter (not . T.null) $ T.splitOn "\n" t
+  forM ls $ \line ->
     case T.splitOn ": " line of
       [name, value] -> return (name, value)
       (name:values) -> return (name, T.intercalate ": " values)
@@ -91,7 +91,7 @@ pTernary :: Parser (Expr, Expr)
 pTernary = do
   reservedOp "?"
   true <- pExpr
-  colon
+  _ <- colon
   false <- pExpr
   return (true, false)
 
@@ -100,11 +100,11 @@ pTernary = do
 -- starting from @nplurals=@.
 pPlural :: Parser (Int, Expr)
 pPlural = do
-  symbol "nplurals"
+  _ <- symbol "nplurals"
   reservedOp "="
   n <- natural
-  semi
-  symbol "plural"
+  _ <- semi
+  _ <- symbol "plural"
   reservedOp "="
   expr <- pExpr
   return (n, expr)

--- a/lib/Data/Gettext/Plural.hs
+++ b/lib/Data/Gettext/Plural.hs
@@ -77,4 +77,4 @@ eval (If cond true false) n =
 eval (Binary op x y) n =
   evalOp op (eval x n) (eval y n)
 eval (Negate x) n = negate $ eval x n
-
+eval (Not x) n = if eval x n == 0 then 1 else eval x n

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+set -e
+
+## TODO clean artifacts regardless
+
+### Helpers
+
+# Clean stale artifacts from previous runs.
+function cleanArtifacts {
+    echo "Cleaning artifacts…"
+    find test/shelltest/ -type f \
+        -regextype posix-egrep -regex ".*\.po" -delete
+}
+
+
+### Program
+
+clear
+
+if ! which shelltest > /dev/null; then
+  echo "shelltest not installed, install it (shelltestrunner)!"
+  exit 1
+fi
+
+cabal build hgettext
+Bin=$(cabal list-bin hgettext)
+
+
+# Run all tests, and clean before (always) and after (only if shelltest
+# exits without errors).
+cleanArtifacts
+shelltest --color --execdir --with "$Bin" test/shelltest/
+cleanArtifacts

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,10 @@
 #! /bin/bash
 set -e
 
-## TODO clean artifacts regardless
+# Run shelltestrunner tests.
+# Translation artifacts will be cleaned always before running tests,
+# and after *only if the testuite succeded* (to ease debugging).
+# If you want to clean atifacts manually, type `./run-tests.sh clean`.
 
 ### Helpers
 
@@ -22,12 +25,17 @@ if ! which shelltest > /dev/null; then
   exit 1
 fi
 
+if [ "$1" = "clean" ]; then
+  cleanArtifacts
+  exit
+fi
+
+# Build and fetch proper binary.
 cabal build hgettext
 Bin=$(cabal list-bin hgettext)
 
 
-# Run all tests, and clean before (always) and after (only if shelltest
-# exits without errors).
+# Run all tests.
 cleanArtifacts
 shelltest --color --execdir --with "$Bin" test/shelltest/
 cleanArtifacts

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.11
+resolver: lts-23.17
 
 packages:
 - '.'

--- a/test/shelltest/I18N/Menu.hs
+++ b/test/shelltest/I18N/Menu.hs
@@ -1,0 +1,1 @@
+nonLatin = __ "© 1499 Francesco Colonna"

--- a/test/shelltest/I18N/unicode.test
+++ b/test/shelltest/I18N/unicode.test
@@ -1,0 +1,3 @@
+# 1. Do not mangle non-latin characters.
+$ hgettext Menu.hs && cat messages.po
+> /©/

--- a/test/shelltest/exceptions/empty.test
+++ b/test/shelltest/exceptions/empty.test
@@ -1,9 +1,14 @@
-# 1.Print helpful text on missing input.
+# 1. Print helpful text on missing input.
 $ hgettext
 hgettext: missing arguments
 >= 0
 
-# 2.Do not create messages.po on missing input.
+# 2. Print helpful text on missing input even with options.
+$ hgettext --output out.po
+hgettext: missing arguments
+>= 0
+
+# 3. Do not create messages.po on missing input.
 $ hgettext && ls
-> /!messages.po/
+> !/messages.po/
 >= 0

--- a/test/shelltest/exceptions/empty.test
+++ b/test/shelltest/exceptions/empty.test
@@ -1,0 +1,9 @@
+# 1.Print helpful text on missing input.
+$ hgettext
+hgettext: missing arguments
+>= 0
+
+# 2.Do not create messages.po on missing input.
+$ hgettext && ls
+> /!messages.po/
+>= 0

--- a/test/shelltest/options/Menu.hs
+++ b/test/shelltest/options/Menu.hs
@@ -1,4 +1,7 @@
 module Menu where
 
 intro :: Loc a
-intro = __ "Welcome!"
+intro = __ "Default"
+
+different :: Loc a
+different = __s "User defined"

--- a/test/shelltest/options/Menu.hs
+++ b/test/shelltest/options/Menu.hs
@@ -1,0 +1,4 @@
+module Menu where
+
+intro :: Loc a
+intro = __ "Welcome!"

--- a/test/shelltest/options/options.test
+++ b/test/shelltest/options/options.test
@@ -13,3 +13,7 @@ $ hgettext --default-domain dom Menu.hs && ls
 # 4. Get `default domain` argument (short).
 $ hgettext -d dom Menu.hs && ls
 > /dom.po/
+
+# 5. Print help.
+$ hgettext --help Menu.hs
+> /Show this help text/

--- a/test/shelltest/options/options.test
+++ b/test/shelltest/options/options.test
@@ -17,3 +17,11 @@ $ hgettext -d dom Menu.hs && ls
 # 5. Print help.
 $ hgettext --help Menu.hs
 > /Show this help text/
+
+# 6. Read strings (default keyword).
+$ hgettext Menu.hs && cat messages.po
+> /Default/
+
+# 7. Read strings (user defined keyword).
+$ hgettext --keyword __s Menu.hs && cat messages.po
+> /User defined/

--- a/test/shelltest/options/options.test
+++ b/test/shelltest/options/options.test
@@ -1,0 +1,16 @@
+# Get `output` argument.
+# 1. Get `output` argument.
+$ hgettext --output out.po && ls
+> /out.po/
+
+# 2. Get `output` argument (short).
+$ hgettext -o out.po && ls
+> /out.po/
+
+# 3. Get `default domain` argument.
+$ hgettext --default-domain dom && ls
+> /dom.po/
+
+# 3. Get `default domain` argument (short).
+$ hgettext -d dom && ls
+> /dom.po/

--- a/test/shelltest/options/options.test
+++ b/test/shelltest/options/options.test
@@ -1,16 +1,15 @@
-# Get `output` argument.
 # 1. Get `output` argument.
-$ hgettext --output out.po && ls
+$ hgettext --output out.po Menu.hs && ls
 > /out.po/
 
 # 2. Get `output` argument (short).
-$ hgettext -o out.po && ls
+$ hgettext -o out.po Menu.hs && ls
 > /out.po/
 
 # 3. Get `default domain` argument.
-$ hgettext --default-domain dom && ls
+$ hgettext --default-domain dom Menu.hs && ls
 > /dom.po/
 
-# 3. Get `default domain` argument (short).
-$ hgettext -d dom && ls
+# 4. Get `default domain` argument (short).
+$ hgettext -d dom Menu.hs && ls
 > /dom.po/

--- a/test/shelltest/options/options.test
+++ b/test/shelltest/options/options.test
@@ -25,3 +25,7 @@ $ hgettext Menu.hs && cat messages.po
 # 7. Read strings (user defined keyword).
 $ hgettext --keyword __s Menu.hs && cat messages.po
 > /User defined/
+
+# 8. Show version.
+$ hgettext --version
+> /(from haskell-gettext)/

--- a/test/shelltest/translate/Menu.hs
+++ b/test/shelltest/translate/Menu.hs
@@ -1,0 +1,1 @@
+test = __s "First string."

--- a/test/shelltest/translate/generate.test
+++ b/test/shelltest/translate/generate.test
@@ -1,0 +1,3 @@
+# 1. Update a translation
+$ hgettext -k __s Menu.hs && cat messages.po
+> /First string./


### PR DESCRIPTION
A number of improvements to `hgettext` utility:

1. There is now a test-suite using `shellcheck`.
2. Options are now parsed sensibly using `optparse-applicative`.
3. `hgettext` does not break on unicode.
4. Additional minor bugfixes.

Again I can squash the commits once review is done.